### PR TITLE
Route us_ein tax IDs to org.Identity

### DIFF
--- a/party.go
+++ b/party.go
@@ -8,13 +8,18 @@ import (
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/de"
+	"github.com/invopop/gobl/regimes/us"
 	"github.com/invopop/gobl/tax"
 	"github.com/stripe/stripe-go/v81"
 )
 
 // For more details on Customer Tax IDs in Stripe, see: https://docs.stripe.com/billing/customer/tax-ids
 
-var orgIDKeys = []stripe.TaxIDType{"de_stn"}
+// orgIDKeys lists the Stripe tax ID types that GOBL represents as party
+// identities (org.Identity) rather than tax identities (tax.Identity). These
+// are codes that don't belong to a VAT-like tax scheme, such as the German
+// Steuernummer (de_stn) or the US Employer Identification Number (us_ein).
+var orgIDKeys = []stripe.TaxIDType{stripe.TaxIDTypeDEStn, stripe.TaxIDTypeUSEIN}
 
 // Lookup map for country code to Stripe tax ID type
 var taxIDMapGOBLToStripe = map[l10n.Code]stripe.TaxIDType{
@@ -143,6 +148,13 @@ func ToTaxIDFromOrg(id *org.Identity) *stripe.TaxID {
 			Value: id.Code.String(),
 		}
 	}
+	switch id.Type {
+	case us.IdentityTypeEIN:
+		return &stripe.TaxID{
+			Type:  stripe.TaxIDTypeUSEIN,
+			Value: id.Code.String(),
+		}
+	}
 	return nil
 }
 
@@ -196,8 +208,15 @@ func FromTaxIDToOrg(taxID *stripe.TaxID) *org.Identity {
 	switch taxID.Type {
 	case stripe.TaxIDTypeDEStn:
 		oid = &org.Identity{
-			Key:  de.IdentityKeyTaxNumber,
-			Code: cbc.Code(taxID.Value),
+			Country: l10n.DE.ISO(),
+			Key:     de.IdentityKeyTaxNumber,
+			Code:    cbc.Code(taxID.Value),
+		}
+	case stripe.TaxIDTypeUSEIN:
+		oid = &org.Identity{
+			Country: l10n.US.ISO(),
+			Type:    us.IdentityTypeEIN,
+			Code:    cbc.Code(taxID.Value),
 		}
 	}
 	oid.Normalize()

--- a/party_test.go
+++ b/party_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/de"
+	"github.com/invopop/gobl/regimes/us"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	stripe "github.com/stripe/stripe-go/v81"
@@ -169,7 +170,12 @@ func TestFromTaxIDToOrg(t *testing.T) {
 		{
 			"valid DE STN",
 			&stripe.TaxID{Type: "de_stn", Value: "123456789"},
-			&org.Identity{Key: de.IdentityKeyTaxNumber, Code: cbc.Code("123456789")},
+			&org.Identity{Country: l10n.DE.ISO(), Key: de.IdentityKeyTaxNumber, Code: cbc.Code("123456789")},
+		},
+		{
+			"valid US EIN",
+			&stripe.TaxID{Type: "us_ein", Value: "41-4637166"},
+			&org.Identity{Country: l10n.US.ISO(), Type: us.IdentityTypeEIN, Code: cbc.Code("41-4637166")},
 		},
 		{
 			"invalid type",
@@ -294,8 +300,9 @@ func TestFromCustomer(t *testing.T) {
 				},
 				Identities: []*org.Identity{
 					{
-						Key:  de.IdentityKeyTaxNumber,
-						Code: "123456789",
+						Country: l10n.DE.ISO(),
+						Key:     de.IdentityKeyTaxNumber,
+						Code:    "123456789",
 					},
 				},
 			},
@@ -579,8 +586,9 @@ func TestFromCustomerItalyTaxIDLogic(t *testing.T) {
 				},
 				Identities: []*org.Identity{
 					{
-						Key:  de.IdentityKeyTaxNumber,
-						Code: "123456789",
+						Country: l10n.DE.ISO(),
+						Key:     de.IdentityKeyTaxNumber,
+						Code:    "123456789",
 					},
 				},
 			},
@@ -690,8 +698,9 @@ func TestNewSupplierFromAccount(t *testing.T) {
 				Name: "German Business",
 				Identities: []*org.Identity{
 					{
-						Key:  de.IdentityKeyTaxNumber,
-						Code: "123456789",
+						Country: l10n.DE.ISO(),
+						Key:     de.IdentityKeyTaxNumber,
+						Code:    "123456789",
 					},
 				},
 			},


### PR DESCRIPTION
## Problem

Converting a Stripe invoice for a US customer with a `us_ein` tax ID failed when creating the silo entry:

```
fatal: creating silo entry: 422: :(customer > tax_id > code: tax id code must have a valid format)
```

`us_ein` values were being mapped into a GOBL `tax.Identity`, whose `code` must match `^[A-Z0-9]+$`. GOBL would normally strip separators during normalization, **but only when no tax regime exists for the country**. A US regime *does* exist and defines no normalizer, so the hyphen in EIN values (e.g. `41-4637166`) was left in place and validation failed with `code: must be in a valid format`.

There's also a conceptual issue: GOBL's US regime states US entities "do not have an official tax scheme and should omit the `code` field," and defines `us.IdentityTypeEIN` as an **`org.Identity`** type — so an EIN should live in the party's `identities` array, not in `tax_id.code`.

## Fix

Route `us_ein` to a GOBL `org.Identity` (type `EIN`) instead of a `tax.Identity`, mirroring how the German Steuernummer (`de_stn`) is already handled. `org.Identity` codes permit hyphens as separators, so `41-4637166` validates as-is.

- Add `us_ein` to `orgIDKeys` so it's recognized as a party identity in all conversion paths (customer, supplier-from-invoice, supplier-from-account).
- `FromTaxIDToOrg` (Stripe → GOBL): map `us_ein` → `org.Identity{Type: EIN, ...}`.
- `ToTaxIDFromOrg` (GOBL → Stripe): symmetric reverse mapping.
- Both org-identity mappings (`de_stn` and `us_ein`) now also set the identity's `country`, making them self-describing.

Resulting customer representation:

```json
"identities": [
  { "country": "US", "type": "EIN", "code": "41-4637166" }
]
```

## Verification

- End-to-end conversion of the failing invoice now passes envelope validation (previously: `customer: (tax_id: (code: must be in a valid format.))`).
- Added a `us_ein` case to `TestFromTaxIDToOrg` and updated the `de_stn` assertions for the new `country` field.
- Full suite passes (`go test ./...`), `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)